### PR TITLE
Add technical set-up information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,37 @@ development data and encouraging its use to inform decisions within the
 sector.
 
 More information on the [Open development Toolkit](http://opendevtoolkit.net)
+
+
+## How to contribute
+
+See the [guide](https://github.com/zararah/opendevtoolkit/blob/gh-pages/how-to-contribute.md) for details.
+
+
+## Technology set-up
+
+The repository is configured to use [Jekyll](https://jekyllrb.com/) to serve pages as a static site. Use of Jeckyll is supported by [GitHub pages](https://pages.github.com/).
+
+
+## Running a local version
+
+    # Clone the repository and navigate into the directory
+    git clone https://github.com/zararah/opendevtoolkit.git
+    cd opendevtoolkit
+
+    # Set-up jekyll if not already installed (note this requires [RubyGems](https://rubygems.org/pages/download))
+    gem install jekyll
+
+    # Run an on-the-fly development version
+    jekyll serve
+
+    # Open a web browser and navigate to http://127.0.0.1:4000/
+
+
+## Deploying to a web server
+	
+	# Download the repository as above, however output the static files rather than serving on the fly
+	jekyll build
+
+	# The static website files will now be in the '_site' directory
+	# These can be transfered to your server, for example using ftp or scp


### PR DESCRIPTION
Hi Zara, Dale from Development Initiatives here...

Following our initial emails last July, I'm just catching up with the migration of this site as we've finally cleared some other projects. I'm planning to resurrect the opendevtoolkit site on one of our servers. As such I've added a bit of technical set-up info to the readme. Hope this is ok.

As per our email, would be great if we could transfer the ownership of the repo to the `IATI` organisation - does that still sound ok?

Many thanks, 
Dale
